### PR TITLE
Add waveform theme presets and gradient bar rendering

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,18 @@ overlay:
   color: "#FF6B6B"
   bg_color: "#1E1E1E"
 
+  # Theme presets (like Ghostty themes). Set a theme name to apply its
+  # colors, gradient, and opacity.  Leave empty for custom colors above.
+  # Available: dracula, monokai, tokyo-night, catppuccin, gruvbox, nord,
+  #            solarized, one-dark, cyberpunk, matrix, synthwave,
+  #            rose-pine, kanagawa, everforest, github-dark
+  theme: ""
+
+  # Horizontal gradient across the waveform bars (left → right).
+  # When enabled, bars are colored by position instead of a single color.
+  gradient: false
+  gradient_colors: []        # e.g. ["#FF79C6", "#BD93F9", "#8BE9FD"]
+
 # Optional local LLM to tidy up transcribed text
 # (fix punctuation, capitalization, remove filler words)
 # Requires: pip install "tinywhisper[tidier]"

--- a/tinywhisper/app.py
+++ b/tinywhisper/app.py
@@ -308,8 +308,10 @@ class TinyWhisperApp:
             self._overlay.close()
         self._overlay = WaveformOverlay(self._config.overlay)
         self._recorder.amplitude.connect(self._overlay.push_amplitude)
-        log.info("Settings applied: opacity=%.2f, color=%s, bg=%s",
-                 self._config.overlay.opacity, self._config.overlay.color, self._config.overlay.bg_color)
+        log.info("Settings applied: opacity=%.2f, color=%s, bg=%s, theme=%s, gradient=%s",
+                 self._config.overlay.opacity, self._config.overlay.color,
+                 self._config.overlay.bg_color, self._config.overlay.theme or "custom",
+                 self._config.overlay.gradient)
 
         # Reinitialize tidier with updated settings
         if self._config.tidier.enabled:

--- a/tinywhisper/config.py
+++ b/tinywhisper/config.py
@@ -49,6 +49,9 @@ class OverlayConfig:
     opacity: float = 0.85
     color: str = "#FF6B6B"
     bg_color: str = "#1E1E1E"
+    theme: str = ""  # theme name from themes.py, empty = custom
+    gradient: bool = False
+    gradient_colors: list[str] = field(default_factory=list)  # left-to-right color stops
 
 
 @dataclass

--- a/tinywhisper/overlay.py
+++ b/tinywhisper/overlay.py
@@ -9,6 +9,30 @@ from PyQt6.QtWidgets import QApplication, QWidget
 from tinywhisper.config import OverlayConfig
 
 
+def _lerp_color(c1: QColor, c2: QColor, t: float) -> QColor:
+    """Linearly interpolate between two colors."""
+    return QColor(
+        int(c1.red() + (c2.red() - c1.red()) * t),
+        int(c1.green() + (c2.green() - c1.green()) * t),
+        int(c1.blue() + (c2.blue() - c1.blue()) * t),
+    )
+
+
+def gradient_color_at(colors: list[QColor], t: float) -> QColor:
+    """Return the interpolated color at position *t* (0.0 – 1.0) along
+    an evenly-spaced gradient defined by *colors*."""
+    if not colors:
+        return QColor("#FF6B6B")
+    if len(colors) == 1:
+        return QColor(colors[0])
+    t = max(0.0, min(1.0, t))
+    segment = t * (len(colors) - 1)
+    idx = int(segment)
+    if idx >= len(colors) - 1:
+        return QColor(colors[-1])
+    return _lerp_color(colors[idx], colors[idx + 1], segment - idx)
+
+
 class WaveformOverlay(QWidget):
     """A frameless, transparent, always-on-top overlay with gradient waveform."""
 
@@ -20,6 +44,10 @@ class WaveformOverlay(QWidget):
         self._bars: deque[float] = deque(maxlen=self.MAX_BARS)
         self._color = QColor(config.color)
         self._bg_color = QColor(config.bg_color)
+
+        # Gradient support
+        self._gradient = config.gradient and len(config.gradient_colors) >= 2
+        self._gradient_colors = [QColor(c) for c in config.gradient_colors]
 
         self.setWindowFlags(
             Qt.WindowType.FramelessWindowHint
@@ -79,20 +107,33 @@ class WaveformOverlay(QWidget):
             painter.end()
             return
 
-        # --- Waveform bars with vertical gradient ---
+        # --- Waveform bars ---
         bar_w = max(3, (w - 24) // self.MAX_BARS - 1)
         gap = 1
         total_bar_w = self.MAX_BARS * (bar_w + gap) - gap
         x_start = (w - total_bar_w) / 2
         mid_y = h / 2
+        n_bars = len(self._bars)
 
         painter.setPen(Qt.PenStyle.NoPen)
-        painter.setBrush(self._color)
 
         for i, amp in enumerate(self._bars):
             bar_h = max(3, int(amp * (h - 18)))
             x = x_start + i * (bar_w + gap)
             y = mid_y - bar_h / 2
+
+            if self._gradient:
+                # Position-based color: use bar index relative to total slots
+                t = i / max(1, self.MAX_BARS - 1)
+                color = gradient_color_at(self._gradient_colors, t)
+                # Fade older (leftmost) bars slightly for depth
+                if n_bars < self.MAX_BARS:
+                    age = 1.0 - (i / max(1, n_bars))
+                    color.setAlpha(int(255 * (0.5 + 0.5 * (1.0 - age))))
+                painter.setBrush(color)
+            else:
+                painter.setBrush(self._color)
+
             painter.drawRoundedRect(QRectF(x, y, bar_w, bar_h), 1.5, 1.5)
 
         painter.end()

--- a/tinywhisper/settings.py
+++ b/tinywhisper/settings.py
@@ -20,6 +20,8 @@ from PyQt6.QtWidgets import (
 )
 
 from tinywhisper.config import AppConfig, CONFIG_DIR, CONFIG_PATH
+from tinywhisper.overlay import gradient_color_at
+from tinywhisper.themes import THEMES, THEME_ORDER
 
 import yaml
 
@@ -34,6 +36,8 @@ class WaveformPreview(QWidget):
         self._opacity = 0.85
         self._color = QColor("#FF6B6B")
         self._bg_color = QColor("#1E1E1E")
+        self._gradient = False
+        self._gradient_colors: list[QColor] = []
         self._phase = 0.0
         self._bars: list[float] = [0.0] * self.MAX_BARS
 
@@ -62,6 +66,12 @@ class WaveformPreview(QWidget):
 
     def set_bg_color(self, color: QColor):
         self._bg_color = color
+        self.update()
+
+    def set_gradient(self, enabled: bool, colors: list[QColor] | None = None):
+        self._gradient = enabled and colors is not None and len(colors) >= 2
+        if colors is not None:
+            self._gradient_colors = list(colors)
         self.update()
 
     def _tick(self):
@@ -96,7 +106,7 @@ class WaveformPreview(QWidget):
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawRoundedRect(QRectF(0.5, 0.5, w - 1, h - 1), 14, 14)
 
-        # Bars with gradient
+        # Bars
         bar_w = max(3, (w - 24) // self.MAX_BARS - 1)
         gap = 1
         total_bar_w = self.MAX_BARS * (bar_w + gap) - gap
@@ -104,14 +114,38 @@ class WaveformPreview(QWidget):
         mid_y = h / 2
 
         painter.setPen(Qt.PenStyle.NoPen)
-        painter.setBrush(self._color)
         for i, amp in enumerate(self._bars):
             bh = max(3, int(amp * (h - 18)))
             x = x_start + i * (bar_w + gap)
             y = mid_y - bh / 2
+
+            if self._gradient and self._gradient_colors:
+                t = i / max(1, self.MAX_BARS - 1)
+                color = gradient_color_at(self._gradient_colors, t)
+                painter.setBrush(color)
+            else:
+                painter.setBrush(self._color)
+
             painter.drawRoundedRect(QRectF(x, y, bar_w, bh), 1.5, 1.5)
 
         painter.end()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COLOR_BTN_STYLE = (
+    "background-color: {hex}; border: 1px solid #888; border-radius: 4px;"
+)
+
+
+def _make_color_btn(color: QColor, callback) -> QPushButton:
+    btn = QPushButton()
+    btn.setFixedSize(60, 28)
+    btn.setStyleSheet(_COLOR_BTN_STYLE.format(hex=color.name()))
+    btn.clicked.connect(callback)
+    return btn
 
 
 class SettingsWindow(QWidget):
@@ -130,8 +164,19 @@ class SettingsWindow(QWidget):
         self._color = QColor(config.overlay.color)
         self._bg_color = QColor(config.overlay.bg_color)
 
+        # Gradient state
+        grad_colors = config.overlay.gradient_colors
+        self._grad_start = QColor(grad_colors[0]) if grad_colors else QColor("#FF6B6B")
+        self._grad_end = QColor(grad_colors[-1]) if grad_colors else QColor("#8BE9FD")
+        self._grad_mid = (
+            QColor(grad_colors[len(grad_colors) // 2])
+            if len(grad_colors) >= 3
+            else None
+        )
+        self._gradient_colors_raw = list(grad_colors)  # keep full list from themes
+
         self.setWindowTitle("TinyWhisper Advanced Settings")
-        self.setFixedSize(420, 720)
+        self.setFixedSize(420, 820)
         self.setWindowFlags(
             Qt.WindowType.Window | Qt.WindowType.WindowStaysOnTopHint
         )
@@ -170,12 +215,37 @@ class SettingsWindow(QWidget):
         ov_header.setStyleSheet("font-weight: bold;")
         layout.addWidget(ov_header)
 
+        # Theme selector
+        theme_row = QHBoxLayout()
+        theme_row.addWidget(QLabel("Theme"))
+        self._theme_combo = QComboBox()
+        self._theme_combo.addItem("Custom")
+        for key in THEME_ORDER:
+            self._theme_combo.addItem(THEMES[key].label, key)
+        # Set current theme
+        current_theme = config.overlay.theme
+        if current_theme and current_theme in THEMES:
+            idx = THEME_ORDER.index(current_theme) + 1  # +1 for "Custom"
+            self._theme_combo.setCurrentIndex(idx)
+        else:
+            self._theme_combo.setCurrentIndex(0)
+        self._theme_combo.currentIndexChanged.connect(self._on_theme_changed)
+        theme_row.addWidget(self._theme_combo, 1)
+        layout.addLayout(theme_row)
+
+        layout.addSpacing(4)
+
         # Live preview
         self._preview = WaveformPreview()
         self._preview.setFixedHeight(60)
         self._preview.set_opacity(config.overlay.opacity)
         self._preview.set_color(self._color)
         self._preview.set_bg_color(self._bg_color)
+        self._preview.set_gradient(
+            config.overlay.gradient,
+            [QColor(c) for c in config.overlay.gradient_colors]
+            if config.overlay.gradient_colors else None,
+        )
         layout.addWidget(self._preview)
 
         layout.addSpacing(4)
@@ -214,11 +284,8 @@ class SettingsWindow(QWidget):
 
         # Waveform color picker
         wave_color_row = QHBoxLayout()
-        wave_color_row.addWidget(QLabel("Waveform Color"))
-        self._color_btn = QPushButton()
-        self._color_btn.setFixedSize(60, 28)
-        self._update_color_btn()
-        self._color_btn.clicked.connect(self._pick_color)
+        wave_color_row.addWidget(QLabel("Bar Color"))
+        self._color_btn = _make_color_btn(self._color, self._pick_color)
         wave_color_row.addWidget(self._color_btn)
         wave_color_row.addStretch()
         layout.addLayout(wave_color_row)
@@ -226,13 +293,37 @@ class SettingsWindow(QWidget):
         # Background color picker
         bg_color_row = QHBoxLayout()
         bg_color_row.addWidget(QLabel("Background Color"))
-        self._bg_color_btn = QPushButton()
-        self._bg_color_btn.setFixedSize(60, 28)
-        self._update_bg_color_btn()
-        self._bg_color_btn.clicked.connect(self._pick_bg_color)
+        self._bg_color_btn = _make_color_btn(self._bg_color, self._pick_bg_color)
         bg_color_row.addWidget(self._bg_color_btn)
         bg_color_row.addStretch()
         layout.addLayout(bg_color_row)
+
+        # ── Gradient ─────────────────────────────────────────────────────────
+        grad_row = QHBoxLayout()
+        grad_row.addWidget(QLabel("Bar Gradient"))
+        self._grad_check = QCheckBox()
+        self._grad_check.setChecked(config.overlay.gradient)
+        self._grad_check.toggled.connect(self._on_gradient_toggled)
+        grad_row.addStretch()
+        grad_row.addWidget(self._grad_check)
+        layout.addLayout(grad_row)
+
+        # Gradient color pickers (start / end)
+        self._grad_colors_row = QHBoxLayout()
+        self._grad_colors_row.addWidget(QLabel("Start"))
+        self._grad_start_btn = _make_color_btn(self._grad_start, self._pick_grad_start)
+        self._grad_colors_row.addWidget(self._grad_start_btn)
+        self._grad_colors_row.addSpacing(8)
+        self._grad_colors_row.addWidget(QLabel("End"))
+        self._grad_end_btn = _make_color_btn(self._grad_end, self._pick_grad_end)
+        self._grad_colors_row.addWidget(self._grad_end_btn)
+        self._grad_colors_row.addStretch()
+
+        # Wrap in a widget so we can show/hide it
+        self._grad_colors_widget = QWidget()
+        self._grad_colors_widget.setLayout(self._grad_colors_row)
+        self._grad_colors_widget.setVisible(config.overlay.gradient)
+        layout.addWidget(self._grad_colors_widget)
 
         # ── Tidier ──────────────────────────────────────────────────────────
         layout.addSpacing(12)
@@ -284,9 +375,72 @@ class SettingsWindow(QWidget):
         save_btn.clicked.connect(self._save)
         layout.addWidget(save_btn)
 
+        # Track whether we're programmatically updating controls
+        self._updating = False
+
+    # ── Theme handling ────────────────────────────────────────────────────
+
+    def _on_theme_changed(self, index: int):
+        if self._updating:
+            return
+        if index == 0:
+            # "Custom" selected — keep current values
+            return
+        theme_key = self._theme_combo.itemData(index)
+        if theme_key is None or theme_key not in THEMES:
+            return
+        theme = THEMES[theme_key]
+
+        self._updating = True
+
+        # Apply theme values to controls
+        self._color = QColor(theme.color)
+        self._bg_color = QColor(theme.bg_color)
+        self._update_color_btn()
+        self._update_bg_color_btn()
+        self._preview.set_color(self._color)
+        self._preview.set_bg_color(self._bg_color)
+
+        # Opacity
+        self._opacity_slider.setValue(int(theme.opacity * 100))
+
+        # Gradient
+        has_gradient = len(theme.gradient_colors) >= 2
+        self._grad_check.setChecked(has_gradient)
+        if has_gradient:
+            self._grad_start = QColor(theme.gradient_colors[0])
+            self._grad_end = QColor(theme.gradient_colors[-1])
+            self._gradient_colors_raw = list(theme.gradient_colors)
+            self._grad_start_btn.setStyleSheet(
+                _COLOR_BTN_STYLE.format(hex=self._grad_start.name())
+            )
+            self._grad_end_btn.setStyleSheet(
+                _COLOR_BTN_STYLE.format(hex=self._grad_end.name())
+            )
+            gc = [QColor(c) for c in theme.gradient_colors]
+            self._preview.set_gradient(True, gc)
+        else:
+            self._gradient_colors_raw = []
+            self._preview.set_gradient(False)
+
+        self._grad_colors_widget.setVisible(has_gradient)
+
+        self._updating = False
+
+    def _mark_custom(self):
+        """Switch the theme dropdown to Custom when the user manually edits a value."""
+        if not self._updating:
+            self._updating = True
+            self._theme_combo.setCurrentIndex(0)
+            self._updating = False
+
+    # ── Tidier ────────────────────────────────────────────────────────────
+
     def _on_tidier_toggled(self, enabled: bool):
         self._tidier_model_combo.setEnabled(enabled)
         self._tidier_prompt.setEnabled(enabled)
+
+    # ── Overlay callbacks ─────────────────────────────────────────────────
 
     def showEvent(self, a0):  # type: ignore[override]
         super().showEvent(a0)
@@ -300,23 +454,25 @@ class SettingsWindow(QWidget):
     def _on_opacity_changed(self, value: int):
         self._opacity_label.setText(f"{value}%")
         self._preview.set_opacity(value / 100.0)
+        self._mark_custom()
 
     def _update_color_btn(self):
         self._color_btn.setStyleSheet(
-            f"background-color: {self._color.name()}; border: 1px solid #888; border-radius: 4px;"
+            _COLOR_BTN_STYLE.format(hex=self._color.name())
         )
 
     def _update_bg_color_btn(self):
         self._bg_color_btn.setStyleSheet(
-            f"background-color: {self._bg_color.name()}; border: 1px solid #888; border-radius: 4px;"
+            _COLOR_BTN_STYLE.format(hex=self._bg_color.name())
         )
 
     def _pick_color(self):
-        color = QColorDialog.getColor(self._color, self, "Waveform Color")
+        color = QColorDialog.getColor(self._color, self, "Bar Color")
         if color.isValid():
             self._color = color
             self._update_color_btn()
             self._preview.set_color(color)
+            self._mark_custom()
 
     def _pick_bg_color(self):
         color = QColorDialog.getColor(self._bg_color, self, "Background Color")
@@ -324,6 +480,49 @@ class SettingsWindow(QWidget):
             self._bg_color = color
             self._update_bg_color_btn()
             self._preview.set_bg_color(color)
+            self._mark_custom()
+
+    # ── Gradient callbacks ────────────────────────────────────────────────
+
+    def _on_gradient_toggled(self, checked: bool):
+        self._grad_colors_widget.setVisible(checked)
+        if checked:
+            gc = self._current_gradient_qcolors()
+            self._preview.set_gradient(True, gc)
+        else:
+            self._preview.set_gradient(False)
+        self._mark_custom()
+
+    def _current_gradient_qcolors(self) -> list[QColor]:
+        """Build the QColor list from current gradient state."""
+        if self._gradient_colors_raw and len(self._gradient_colors_raw) >= 2:
+            return [QColor(c) for c in self._gradient_colors_raw]
+        return [QColor(self._grad_start), QColor(self._grad_end)]
+
+    def _pick_grad_start(self):
+        color = QColorDialog.getColor(self._grad_start, self, "Gradient Start")
+        if color.isValid():
+            self._grad_start = color
+            self._grad_start_btn.setStyleSheet(
+                _COLOR_BTN_STYLE.format(hex=color.name())
+            )
+            # Reset raw list to 2-stop when user manually picks
+            self._gradient_colors_raw = [self._grad_start.name(), self._grad_end.name()]
+            self._preview.set_gradient(True, self._current_gradient_qcolors())
+            self._mark_custom()
+
+    def _pick_grad_end(self):
+        color = QColorDialog.getColor(self._grad_end, self, "Gradient End")
+        if color.isValid():
+            self._grad_end = color
+            self._grad_end_btn.setStyleSheet(
+                _COLOR_BTN_STYLE.format(hex=color.name())
+            )
+            self._gradient_colors_raw = [self._grad_start.name(), self._grad_end.name()]
+            self._preview.set_gradient(True, self._current_gradient_qcolors())
+            self._mark_custom()
+
+    # ── Save ──────────────────────────────────────────────────────────────
 
     def _save(self):
         # Hotkey
@@ -342,6 +541,26 @@ class SettingsWindow(QWidget):
         self._config.overlay.height = self._height_spin.value()
         self._config.overlay.color = self._color.name()
         self._config.overlay.bg_color = self._bg_color.name()
+
+        # Theme
+        idx = self._theme_combo.currentIndex()
+        if idx > 0:
+            self._config.overlay.theme = self._theme_combo.itemData(idx) or ""
+        else:
+            self._config.overlay.theme = ""
+
+        # Gradient
+        self._config.overlay.gradient = self._grad_check.isChecked()
+        if self._config.overlay.gradient:
+            if self._gradient_colors_raw and len(self._gradient_colors_raw) >= 2:
+                self._config.overlay.gradient_colors = list(self._gradient_colors_raw)
+            else:
+                self._config.overlay.gradient_colors = [
+                    self._grad_start.name(),
+                    self._grad_end.name(),
+                ]
+        else:
+            self._config.overlay.gradient_colors = []
 
         # Tidier
         self._config.tidier.enabled = self._tidier_enabled.isChecked()
@@ -372,6 +591,9 @@ class SettingsWindow(QWidget):
                 "opacity": self._config.overlay.opacity,
                 "color": self._config.overlay.color,
                 "bg_color": self._config.overlay.bg_color,
+                "theme": self._config.overlay.theme,
+                "gradient": self._config.overlay.gradient,
+                "gradient_colors": self._config.overlay.gradient_colors,
             },
             "tidier": {
                 "enabled": self._config.tidier.enabled,

--- a/tinywhisper/themes.py
+++ b/tinywhisper/themes.py
@@ -1,0 +1,114 @@
+"""Built-in waveform themes inspired by popular coding color schemes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Theme:
+    label: str
+    color: str  # solid bar color (used when gradient is off)
+    bg_color: str
+    gradient_colors: list[str] = field(default_factory=list)  # left-to-right
+    opacity: float = 0.90
+
+
+# Ordered dict of built-in themes.  Keys are config identifiers.
+THEMES: dict[str, Theme] = {
+    "dracula": Theme(
+        label="Dracula",
+        color="#BD93F9",
+        bg_color="#282A36",
+        gradient_colors=["#FF79C6", "#BD93F9", "#8BE9FD"],
+    ),
+    "monokai": Theme(
+        label="Monokai",
+        color="#A6E22E",
+        bg_color="#272822",
+        gradient_colors=["#A6E22E", "#E6DB74", "#FD971F"],
+    ),
+    "tokyo-night": Theme(
+        label="Tokyo Night",
+        color="#7AA2F7",
+        bg_color="#1A1B26",
+        gradient_colors=["#7AA2F7", "#BB9AF7"],
+    ),
+    "catppuccin": Theme(
+        label="Catppuccin Mocha",
+        color="#CBA6F7",
+        bg_color="#1E1E2E",
+        gradient_colors=["#F5C2E7", "#CBA6F7", "#89B4FA"],
+    ),
+    "gruvbox": Theme(
+        label="Gruvbox",
+        color="#FE8019",
+        bg_color="#282828",
+        gradient_colors=["#FB4934", "#FE8019", "#FABD2F", "#8EC07C"],
+    ),
+    "nord": Theme(
+        label="Nord",
+        color="#88C0D0",
+        bg_color="#2E3440",
+        gradient_colors=["#5E81AC", "#81A1C1", "#88C0D0", "#8FBCBB"],
+    ),
+    "solarized": Theme(
+        label="Solarized Dark",
+        color="#2AA198",
+        bg_color="#002B36",
+        gradient_colors=["#2AA198", "#859900"],
+    ),
+    "one-dark": Theme(
+        label="One Dark",
+        color="#61AFEF",
+        bg_color="#282C34",
+        gradient_colors=["#61AFEF", "#C678DD"],
+    ),
+    "cyberpunk": Theme(
+        label="Cyberpunk",
+        color="#FF2079",
+        bg_color="#0D0221",
+        gradient_colors=["#FF2079", "#F222FF", "#00FFF1"],
+        opacity=0.92,
+    ),
+    "matrix": Theme(
+        label="Matrix",
+        color="#00FF41",
+        bg_color="#0A0A0A",
+        gradient_colors=["#003B00", "#00FF41"],
+        opacity=0.92,
+    ),
+    "synthwave": Theme(
+        label="Synthwave '84",
+        color="#F97E72",
+        bg_color="#2B213A",
+        gradient_colors=["#F97E72", "#FF7EDB", "#36F9F6"],
+    ),
+    "rose-pine": Theme(
+        label="Rose Pine",
+        color="#EBBCBA",
+        bg_color="#191724",
+        gradient_colors=["#EBBCBA", "#F6C177", "#C4A7E7"],
+    ),
+    "kanagawa": Theme(
+        label="Kanagawa",
+        color="#7E9CD8",
+        bg_color="#1F1F28",
+        gradient_colors=["#7E9CD8", "#957FB8", "#D27E99"],
+    ),
+    "everforest": Theme(
+        label="Everforest",
+        color="#A7C080",
+        bg_color="#2D353B",
+        gradient_colors=["#83C092", "#A7C080", "#DBBC7F"],
+    ),
+    "github-dark": Theme(
+        label="GitHub Dark",
+        color="#58A6FF",
+        bg_color="#0D1117",
+        gradient_colors=["#58A6FF", "#3FB950"],
+    ),
+}
+
+# Display order for UI
+THEME_ORDER: list[str] = list(THEMES.keys())


### PR DESCRIPTION
Introduce a theme system with 15 coding-inspired color schemes
(Dracula, Monokai, Tokyo Night, Catppuccin, Cyberpunk, Matrix, etc.)
selectable from the settings UI. Add horizontal gradient support so
waveform bars are colored by position via multi-stop color interpolation.
The settings window gains a theme dropdown with live preview, a gradient
toggle, and start/end gradient color pickers. Manually tweaking any
value automatically switches the theme to "Custom". All new options
(theme, gradient, gradient_colors) persist in config.yaml.

https://claude.ai/code/session_011SouxSyvrTkRYPj7uWNx94