### PR TITLE
Add copy buttons for last transcription to taskbar dropdown

### DIFF
--- a/tinywhisper/app.py
+++ b/tinywhisper/app.py
@@ -12,6 +12,8 @@ from PyQt6.QtCore import QTimer
 from PyQt6.QtGui import QAction, QActionGroup
 from PyQt6.QtWidgets import QApplication, QMenu, QSystemTrayIcon
 
+import pyperclip
+
 from tinywhisper.clipboard import paste_text
 from tinywhisper.config import AppConfig, CONFIG_PATH
 from tinywhisper.hotkey import HotkeyListener, request_access
@@ -46,6 +48,8 @@ class TinyWhisperApp:
         self._recording = False
         self._ready = False
         self._worker: TranscriptionWorker | None = None
+        self._last_raw_text: str = ""
+        self._last_tidied_text: str = ""
 
         # Request Input Monitoring permission (triggers macOS prompt on first run)
         request_access()
@@ -104,6 +108,17 @@ class TinyWhisperApp:
         self._status_action = QAction("Ready", menu)
         self._status_action.setEnabled(False)
         menu.addAction(self._status_action)
+
+        # Copy last transcription buttons
+        self._copy_raw_action = QAction("Copy Last Transcription", menu)
+        self._copy_raw_action.setEnabled(False)
+        self._copy_raw_action.triggered.connect(self._copy_last_raw)
+        menu.addAction(self._copy_raw_action)
+
+        self._copy_tidied_action = QAction("Copy Last Tidied Transcription", menu)
+        self._copy_tidied_action.setEnabled(False)
+        self._copy_tidied_action.triggered.connect(self._copy_last_tidied)
+        menu.addAction(self._copy_tidied_action)
 
         menu.addSeparator()
 
@@ -270,10 +285,20 @@ class TinyWhisperApp:
 
     def _run_transcription(self, wav_path: Path):
         self._worker = TranscriptionWorker(self._engine, wav_path, tidier=self._tidier)
+        self._worker.raw_finished.connect(self._on_raw_transcription)
         self._worker.finished.connect(self._on_transcription_done)
         self._worker.error.connect(self._on_transcription_error)
         self._worker.tidying.connect(lambda: self._set_status("Tidying…"))
         self._worker.start()
+
+    def _on_raw_transcription(self, text: str):
+        """Store raw transcription text for later copying."""
+        if text:
+            self._last_raw_text = text
+            self._copy_raw_action.setEnabled(True)
+            # Reset tidied text until tidying finishes (or doesn't run)
+            self._last_tidied_text = ""
+            self._copy_tidied_action.setEnabled(False)
 
     def _on_transcription_done(self, text: str):
         try:
@@ -284,6 +309,10 @@ class TinyWhisperApp:
                     "TinyWhisper", "No speech detected.", QSystemTrayIcon.MessageIcon.Warning, 2000
                 )
                 return
+            # Track tidied text if it differs from the raw transcription
+            if text != self._last_raw_text:
+                self._last_tidied_text = text
+                self._copy_tidied_action.setEnabled(True)
             paste_text(text)
         except Exception:
             log.exception("Error in transcription done handler")
@@ -300,6 +329,16 @@ class TinyWhisperApp:
             )
         except Exception:
             log.exception("Error in transcription error handler")
+
+    def _copy_last_raw(self):
+        """Copy the last raw transcription to clipboard."""
+        if self._last_raw_text:
+            pyperclip.copy(self._last_raw_text)
+
+    def _copy_last_tidied(self):
+        """Copy the last tidied transcription to clipboard."""
+        if self._last_tidied_text:
+            pyperclip.copy(self._last_tidied_text)
 
     def _on_settings_changed(self):
         """Rebuild overlay and tidier with new settings."""

--- a/tinywhisper/transcriber.py
+++ b/tinywhisper/transcriber.py
@@ -72,7 +72,8 @@ def create_engine(config: TranscriptionConfig) -> TranscriptionEngine:
 class TranscriptionWorker(QThread):
     """Runs transcription (and optional tidying) in a background thread."""
 
-    finished = pyqtSignal(str)  # transcribed text
+    finished = pyqtSignal(str)  # final text (tidied if enabled, otherwise raw)
+    raw_finished = pyqtSignal(str)  # raw transcription before tidying
     error = pyqtSignal(str)  # error message
     tidying = pyqtSignal()  # emitted when tidying step starts
 
@@ -95,6 +96,7 @@ class TranscriptionWorker(QThread):
             text = self._engine.transcribe(self._wav_path)
             elapsed = time.perf_counter() - t0
             log.info("Transcribed in %.2fs: %s", elapsed, text)
+            self.raw_finished.emit(str(text) if text else "")
 
             if text and self._tidier is not None:
                 self.tidying.emit()


### PR DESCRIPTION
Two new menu items appear below the status line:
- "Copy Last Transcription" — copies the raw speech-to-text output
- "Copy Last Tidied Transcription" — copies the LLM-cleaned version

Both buttons start disabled and enable after the first transcription.
The tidied button only enables when the tidier ran and produced
different output from the raw transcription.

https://claude.ai/code/session_012ndCDwq7WXAFat1YhxLYHF