### PR TITLE
Add missing pynput and AVFoundation dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "dacite>=1.8",
     "parakeet-mlx>=0.1",
     "pyobjc-framework-ServiceManagement>=9.0",
+    "pyobjc-framework-AVFoundation>=9.0",
+    "pynput>=1.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Adds `pynput>=1.7` and `pyobjc-framework-AVFoundation>=9.0` to `pyproject.toml`
- Fresh installs were crashing with `ModuleNotFoundError` because `clipboard.py` imports `pynput` and `welcome.py` imports `AVFoundation`, but neither was listed as a dependency

Closes #13

## Test plan
- [ ] `pip install .` in a clean venv and run `tinywhisper` — no `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)